### PR TITLE
Updated raincatcher getting started guide link

### DIFF
--- a/source/pages/raincatcher.nunjucks
+++ b/source/pages/raincatcher.nunjucks
@@ -47,7 +47,7 @@
 
 <p>To help get started, the modules come with a sample mobile application and Web portal based on Angular.js using Material Design, which you can use to bootstrap your own developments and <a href="http://www.feedhenry.com/release-of-v3-10-of-the-red-hat-mobile-application-platform-including-swift-2-1-and-wfm/">create a solution like this</a></p>
 
-<p>See the <a href="https://github.com/feedhenry-staff/wfm-doc/blob/master/Getting-Started.md">Getting Started Guide</a> as well.</p>
+<p>See the <a href="https://github.com/feedhenry-raincatcher/raincatcher-documentation/blob/master/Getting-Started.md">Getting Started Guide</a> as well.</p>
 
 <h4>Community</h4>
 


### PR DESCRIPTION
## Issue
Getting started guide for Raincatcher has been moved from wfm-docs to a different location:
[https://github.com/feedhenry-raincatcher/raincatcher-documentation/blob/master/Getting-Started.md](url)

## Solution
Update getting started guide link for raincatcher to direct to this new location. 

## JIRA Ticket
https://issues.jboss.org/browse/RHMAP-11367